### PR TITLE
DON'T MERGE! MGDCTRS-109 Add `error_handler` capability for Debezium connectors

### DIFF
--- a/descriptors/mongodb/debezium-mongodb-1.9.0.Alpha1.json
+++ b/descriptors/mongodb/debezium-mongodb-1.9.0.Alpha1.json
@@ -8,7 +8,7 @@
     "channels" : [ "stable" ],
     "description" : null,
     "labels" : [ "source", "debezium", "mongodb", "1.9.0.Alpha1" ],
-    "capabilities" : [ "data_shape" ],
+    "capabilities" : [ "data_shape", "error_handler" ],
     "icon_href" : "http://example.com/images/debezium-mongodb-1.9.0.Alpha1.png",
     "schema" : {
       "title" : "Debezium MongoDB Connector",
@@ -153,6 +153,17 @@
               "x-category" : "CONNECTOR",
               "$ref" : "#/$defs/serializer"
             }
+          }
+        },
+        "error_handler" : {
+          "properties" : {
+            "oneOf" : [ {
+              "required" : [ "stop" ],
+              "additionalProperties" : false,
+              "properties" : {
+                "stop" : { }
+              }
+            } ]
           }
         }
       },

--- a/descriptors/mysql/debezium-mysql-1.9.0.Alpha1.json
+++ b/descriptors/mysql/debezium-mysql-1.9.0.Alpha1.json
@@ -8,7 +8,7 @@
     "channels" : [ "stable" ],
     "description" : null,
     "labels" : [ "source", "debezium", "mysql", "1.9.0.Alpha1" ],
-    "capabilities" : [ "data_shape" ],
+    "capabilities" : [ "data_shape", "error_handler" ],
     "icon_href" : "http://example.com/images/debezium-mysql-1.9.0.Alpha1.png",
     "schema" : {
       "title" : "Debezium MySQL Connector",
@@ -192,6 +192,17 @@
               "x-category" : "CONNECTOR",
               "$ref" : "#/$defs/serializer"
             }
+          }
+        },
+        "error_handler" : {
+          "properties" : {
+            "oneOf" : [ {
+              "required" : [ "stop" ],
+              "additionalProperties" : false,
+              "properties" : {
+                "stop" : { }
+              }
+            } ]
           }
         }
       },

--- a/descriptors/postgres/debezium-postgres-1.9.0.Alpha1.json
+++ b/descriptors/postgres/debezium-postgres-1.9.0.Alpha1.json
@@ -8,7 +8,7 @@
     "channels" : [ "stable" ],
     "description" : null,
     "labels" : [ "source", "debezium", "postgres", "1.9.0.Alpha1" ],
-    "capabilities" : [ "data_shape" ],
+    "capabilities" : [ "data_shape", "error_handler" ],
     "icon_href" : "http://example.com/images/debezium-postgres-1.9.0.Alpha1.png",
     "schema" : {
       "title" : "Debezium PostgreSQL Connector",
@@ -231,6 +231,17 @@
               "x-category" : "CONNECTOR",
               "$ref" : "#/$defs/serializer"
             }
+          }
+        },
+        "error_handler" : {
+          "properties" : {
+            "oneOf" : [ {
+              "required" : [ "stop" ],
+              "additionalProperties" : false,
+              "properties" : {
+                "stop" : { }
+              }
+            } ]
           }
         }
       },

--- a/descriptors/sqlserver/debezium-sqlserver-1.9.0.Alpha1.json
+++ b/descriptors/sqlserver/debezium-sqlserver-1.9.0.Alpha1.json
@@ -8,7 +8,7 @@
     "channels" : [ "stable" ],
     "description" : null,
     "labels" : [ "source", "debezium", "sqlserver", "1.9.0.Alpha1" ],
-    "capabilities" : [ "data_shape" ],
+    "capabilities" : [ "data_shape", "error_handler" ],
     "icon_href" : "http://example.com/images/debezium-sqlserver-1.9.0.Alpha1.png",
     "schema" : {
       "title" : "Debezium SqlSever Connector",
@@ -173,6 +173,17 @@
               "x-category" : "CONNECTOR",
               "$ref" : "#/$defs/serializer"
             }
+          }
+        },
+        "error_handler" : {
+          "properties" : {
+            "oneOf" : [ {
+              "required" : [ "stop" ],
+              "additionalProperties" : false,
+              "properties" : {
+                "stop" : { }
+              }
+            } ]
           }
         }
       },

--- a/src/main/java/io/debezium/mcs/envelope/ConnectorTypesEnvelope.java
+++ b/src/main/java/io/debezium/mcs/envelope/ConnectorTypesEnvelope.java
@@ -40,7 +40,7 @@ public class ConnectorTypesEnvelope {
 
     public final List<String> labels = new LinkedList<>(Arrays.asList("source", "debezium"));
 
-    public final List<String> capabilities = new ArrayList<>(Collections.singletonList("data_shape"));
+    public final List<String> capabilities = new ArrayList<>(List.of("data_shape", "error_handler"));
 
     @JsonProperty("schema")
     public final ObjectNode jsonSchema;

--- a/src/main/resources/additional_properties.json
+++ b/src/main/resources/additional_properties.json
@@ -18,5 +18,16 @@
         "$ref" : "#/$defs/serializer"
       }
     }
+  },
+  "error_handler" : {
+    "properties" : {
+      "oneOf" : [ {
+        "required" : [ "stop" ],
+        "additionalProperties" : false,
+        "properties" : {
+          "stop" : { }
+        }
+      } ]
+    }
   }
 }


### PR DESCRIPTION
**DON'T MERGE YET!**
Eventually we can add `error_handler` capability to the Debezium schema descriptors with this PR. For now let's wait how the ongoing discussions on this topic develop.

Add `error_handler` capability for Debezium connectors. The expected valid API config might look like in this example:

```
{
    "connector.class": "io.debezium.connector.postgresql.PostgresConnector", 
    "database.hostname": "192.168.99.100", 
    "database.port": "5432", 
    "database.user": "postgres", 
    "database.password": "postgres", 
    "database.dbname" : "postgres", 
    "database.server.name": "fulfillment", 
    "table.include.list": "public.inventory",
    "error_handler": "stop"
}
```