### PR TITLE
Move catalog to use 1.9.0.Alpha2 & nightly tag

### DIFF
--- a/descriptors/mongodb/debezium-mongodb-1.9.0.Alpha2.json
+++ b/descriptors/mongodb/debezium-mongodb-1.9.0.Alpha2.json
@@ -1,15 +1,15 @@
 {
   "connector_type" : {
-    "id" : "debezium-mongodb-1.9.0.Alpha1",
+    "id" : "debezium-mongodb-1.9.0.Alpha2",
     "kind" : "ConnectorType",
-    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-mongodb-1.9.0.Alpha1",
+    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-mongodb-1.9.0.Alpha2",
     "name" : "Debezium MongoDB Connector",
-    "version" : "1.9.0.Alpha1",
+    "version" : "1.9.0.Alpha2",
     "channels" : [ "stable" ],
     "description" : null,
-    "labels" : [ "source", "debezium", "mongodb", "1.9.0.Alpha1" ],
+    "labels" : [ "source", "debezium", "mongodb", "1.9.0.Alpha2" ],
     "capabilities" : [ "data_shape" ],
-    "icon_href" : "http://example.com/images/debezium-mongodb-1.9.0.Alpha1.png",
+    "icon_href" : "http://example.com/images/debezium-mongodb-1.9.0.Alpha2.png",
     "schema" : {
       "title" : "Debezium MongoDB Connector",
       "required" : [ "mongodb.name" ],
@@ -17,7 +17,7 @@
       "properties" : {
         "mongodb.name" : {
           "title" : "Namespace",
-          "description" : "Unique name that identifies the MongoDB replica set or cluster and all recorded offsets, andthat is used as a prefix for all schemas and topics. Each distinct MongoDB installation should have a separate namespace and monitored by at most one Debezium connector.",
+          "description" : "Unique name that identifies the MongoDB replica set or cluster and all recorded offsets, and that is used as a prefix for all schemas and topics. Each distinct MongoDB installation should have a separate namespace and monitored by at most one Debezium connector.",
           "type" : "string",
           "nullable" : false,
           "x-name" : "mongodb.name",
@@ -158,7 +158,7 @@
       },
       "additionalProperties" : true,
       "x-connector-id" : "mongodb",
-      "x-version" : "1.9.0.Alpha1",
+      "x-version" : "1.9.0.Alpha2",
       "x-className" : "io.debezium.connector.mongodb.MongoDbConnector",
       "$defs" : {
         "serializer" : {
@@ -171,7 +171,7 @@
   },
   "channels" : {
     "stable" : {
-      "revision" : 3,
+      "revision" : 4,
       "shard_metadata" : {
         "operators" : [ {
           "type" : "debezium-connector-operator",
@@ -179,7 +179,7 @@
         } ],
         "connector_type" : "source",
         "connector_class" : "io.debezium.connector.mongodb.MongoDbConnector",
-        "container_image" : "quay.io/rhoas/cos-connector-debezium-mongodb@sha256:7bcb62e2aa02ef100c86ee2697069e435f8365469d7e3df9126731909b83d016"
+        "container_image" : "quay.io/rhoas/cos-connector-debezium-mongodb:nightly"
       }
     }
   }

--- a/descriptors/mysql/debezium-mysql-1.9.0.Alpha2.json
+++ b/descriptors/mysql/debezium-mysql-1.9.0.Alpha2.json
@@ -1,18 +1,18 @@
 {
   "connector_type" : {
-    "id" : "debezium-postgres-1.9.0.Alpha1",
+    "id" : "debezium-mysql-1.9.0.Alpha2",
     "kind" : "ConnectorType",
-    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-postgres-1.9.0.Alpha1",
-    "name" : "Debezium PostgreSQL Connector",
-    "version" : "1.9.0.Alpha1",
+    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-mysql-1.9.0.Alpha2",
+    "name" : "Debezium MySQL Connector",
+    "version" : "1.9.0.Alpha2",
     "channels" : [ "stable" ],
     "description" : null,
-    "labels" : [ "source", "debezium", "postgres", "1.9.0.Alpha1" ],
+    "labels" : [ "source", "debezium", "mysql", "1.9.0.Alpha2" ],
     "capabilities" : [ "data_shape" ],
-    "icon_href" : "http://example.com/images/debezium-postgres-1.9.0.Alpha1.png",
+    "icon_href" : "http://example.com/images/debezium-mysql-1.9.0.Alpha2.png",
     "schema" : {
-      "title" : "Debezium PostgreSQL Connector",
-      "required" : [ "database.server.name", "database.hostname", "database.user", "database.dbname" ],
+      "title" : "Debezium MySQL Connector",
+      "required" : [ "database.hostname", "database.user", "database.server.name", "database.server.id" ],
       "type" : "object",
       "properties" : {
         "database.server.name" : {
@@ -21,6 +21,16 @@
           "type" : "string",
           "nullable" : false,
           "x-name" : "database.server.name",
+          "x-category" : "CONNECTION"
+        },
+        "database.server.id" : {
+          "format" : "int64",
+          "title" : "Cluster ID",
+          "description" : "A numeric ID of this database client, which must be unique across all currently-running database processes in the cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number is generated between 5400 and 6400.",
+          "default" : 6360,
+          "type" : "integer",
+          "nullable" : false,
+          "x-name" : "database.server.id",
           "x-category" : "CONNECTION"
         },
         "database.hostname" : {
@@ -35,7 +45,7 @@
           "format" : "int32",
           "title" : "Port",
           "description" : "Port of the database server.",
-          "default" : 5432,
+          "default" : 3306,
           "type" : "integer",
           "x-name" : "database.port",
           "x-category" : "CONNECTION"
@@ -64,53 +74,20 @@
           "x-name" : "database.password",
           "x-category" : "CONNECTION"
         },
-        "database.dbname" : {
-          "title" : "Database",
-          "description" : "The name of the database from which the connector should capture changes",
-          "type" : "string",
-          "nullable" : false,
-          "x-name" : "database.dbname",
-          "x-category" : "CONNECTION"
-        },
-        "slot.name" : {
-          "title" : "Slot",
-          "description" : "The name of the Postgres logical decoding slot created for streaming changes from a plugin.Defaults to 'debezium",
-          "default" : "debezium",
-          "type" : "string",
-          "x-name" : "slot.name",
-          "x-category" : "CONNECTION_ADVANCED_REPLICATION"
-        },
-        "publication.name" : {
-          "title" : "Publication",
-          "description" : "The name of the Postgres 10+ publication used for streaming changes from a plugin.Defaults to 'dbz_publication'",
-          "default" : "dbz_publication",
-          "type" : "string",
-          "x-name" : "publication.name",
-          "x-category" : "CONNECTION_ADVANCED_REPLICATION"
-        },
-        "publication.autocreate.mode" : {
-          "title" : "Publication Auto Create Mode",
-          "description" : "Applies only when streaming changes using pgoutput.Determine how creation of a publication should work, the default is all_tables.DISABLED - The connector will not attempt to create a publication at all. The expectation is that the user has created the publication up-front. If the publication isn't found to exist upon startup, the connector will throw an exception and stop.ALL_TABLES - If no publication exists, the connector will create a new publication for all tables. Note this requires that the configured user has access. If the publication already exists, it will be used. i.e CREATE PUBLICATION <publication_name> FOR ALL TABLES;FILTERED - If no publication exists, the connector will create a new publication for all those tables matchingthe current filter configuration (see table/database include/exclude list properties). If the publication already exists, it will be used. i.e CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, etc>",
-          "default" : "all_tables",
-          "enum" : [ "filtered", "disabled", "all_tables" ],
-          "type" : "string",
-          "x-name" : "publication.autocreate.mode",
-          "x-category" : "CONNECTION_ADVANCED_REPLICATION"
-        },
-        "schema.include.list" : {
+        "database.include.list" : {
           "format" : "list,regex",
-          "title" : "Include Schemas",
-          "description" : "The schemas for which events should be captured",
+          "title" : "Include Databases",
+          "description" : "The databases for which changes are to be captured",
           "type" : "string",
-          "x-name" : "schema.include.list",
+          "x-name" : "database.include.list",
           "x-category" : "FILTERS"
         },
-        "schema.exclude.list" : {
+        "database.exclude.list" : {
           "format" : "list,regex",
-          "title" : "Exclude Schemas",
-          "description" : "The schemas for which events must not be captured",
+          "title" : "Exclude Databases",
+          "description" : "A comma-separated list of regular expressions that match database names to be excluded from monitoring",
           "type" : "string",
-          "x-name" : "schema.exclude.list",
+          "x-name" : "database.exclude.list",
           "x-category" : "FILTERS"
         },
         "table.include.list" : {
@@ -147,9 +124,9 @@
         },
         "snapshot.mode" : {
           "title" : "Snapshot mode",
-          "description" : "The criteria for running a snapshot upon startup of the connector. Options include: 'always' to specify that the connector run a snapshot each time it starts up; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally start emitting changes;'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the last position (LSN) recorded by the server; and'exported' deprecated, use 'initial' instead; 'custom' to specify a custom class with 'snapshot.custom_class' which will be loaded and used to determine the snapshot, see docs for more details.",
+          "description" : "The criteria for running a snapshot upon startup of the connector. Options include: 'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; 'schema_only' to only take a snapshot of the schema (table structures) but no actual data; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. The 'never' mode should be used with care, and only when the binlog is known to contain all history.",
           "default" : "initial",
-          "enum" : [ "always", "exported", "never", "initial_only", "initial", "custom" ],
+          "enum" : [ "never", "initial_only", "when_needed", "initial", "schema_only", "schema_only_recovery" ],
           "type" : "string",
           "x-name" : "snapshot.mode",
           "x-category" : "CONNECTOR_SNAPSHOT"
@@ -219,9 +196,9 @@
         }
       },
       "additionalProperties" : true,
-      "x-connector-id" : "postgres",
-      "x-version" : "1.9.0.Alpha1",
-      "x-className" : "io.debezium.connector.postgresql.PostgresConnector",
+      "x-connector-id" : "mysql",
+      "x-version" : "1.9.0.Alpha2",
+      "x-className" : "io.debezium.connector.mysql.MySqlConnector",
       "$defs" : {
         "serializer" : {
           "type" : "string",
@@ -233,15 +210,15 @@
   },
   "channels" : {
     "stable" : {
-      "revision" : 3,
+      "revision" : 4,
       "shard_metadata" : {
         "operators" : [ {
           "type" : "debezium-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
         "connector_type" : "source",
-        "connector_class" : "io.debezium.connector.postgresql.PostgresConnector",
-        "container_image" : "quay.io/rhoas/cos-connector-debezium-postgres@sha256:3d86a5b1e0c998895699e6ca1bfbf1c6c41907037392346bb09710bdee895b55"
+        "connector_class" : "io.debezium.connector.mysql.MySqlConnector",
+        "container_image" : "quay.io/rhoas/cos-connector-debezium-mysql:nightly"
       }
     }
   }

--- a/descriptors/postgres/debezium-postgres-1.9.0.Alpha2.json
+++ b/descriptors/postgres/debezium-postgres-1.9.0.Alpha2.json
@@ -1,18 +1,18 @@
 {
   "connector_type" : {
-    "id" : "debezium-mysql-1.9.0.Alpha1",
+    "id" : "debezium-postgres-1.9.0.Alpha2",
     "kind" : "ConnectorType",
-    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-mysql-1.9.0.Alpha1",
-    "name" : "Debezium MySQL Connector",
-    "version" : "1.9.0.Alpha1",
+    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-postgres-1.9.0.Alpha2",
+    "name" : "Debezium PostgreSQL Connector",
+    "version" : "1.9.0.Alpha2",
     "channels" : [ "stable" ],
     "description" : null,
-    "labels" : [ "source", "debezium", "mysql", "1.9.0.Alpha1" ],
+    "labels" : [ "source", "debezium", "postgres", "1.9.0.Alpha2" ],
     "capabilities" : [ "data_shape" ],
-    "icon_href" : "http://example.com/images/debezium-mysql-1.9.0.Alpha1.png",
+    "icon_href" : "http://example.com/images/debezium-postgres-1.9.0.Alpha2.png",
     "schema" : {
-      "title" : "Debezium MySQL Connector",
-      "required" : [ "database.hostname", "database.user", "database.server.name", "database.server.id" ],
+      "title" : "Debezium PostgreSQL Connector",
+      "required" : [ "database.server.name", "database.hostname", "database.user", "database.dbname" ],
       "type" : "object",
       "properties" : {
         "database.server.name" : {
@@ -21,16 +21,6 @@
           "type" : "string",
           "nullable" : false,
           "x-name" : "database.server.name",
-          "x-category" : "CONNECTION"
-        },
-        "database.server.id" : {
-          "format" : "int64",
-          "title" : "Cluster ID",
-          "description" : "A numeric ID of this database client, which must be unique across all currently-running database processes in the cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number is generated between 5400 and 6400.",
-          "default" : 5405,
-          "type" : "integer",
-          "nullable" : false,
-          "x-name" : "database.server.id",
           "x-category" : "CONNECTION"
         },
         "database.hostname" : {
@@ -45,7 +35,7 @@
           "format" : "int32",
           "title" : "Port",
           "description" : "Port of the database server.",
-          "default" : 3306,
+          "default" : 5432,
           "type" : "integer",
           "x-name" : "database.port",
           "x-category" : "CONNECTION"
@@ -74,20 +64,53 @@
           "x-name" : "database.password",
           "x-category" : "CONNECTION"
         },
-        "database.include.list" : {
-          "format" : "list,regex",
-          "title" : "Include Databases",
-          "description" : "The databases for which changes are to be captured",
+        "database.dbname" : {
+          "title" : "Database",
+          "description" : "The name of the database from which the connector should capture changes",
           "type" : "string",
-          "x-name" : "database.include.list",
+          "nullable" : false,
+          "x-name" : "database.dbname",
+          "x-category" : "CONNECTION"
+        },
+        "slot.name" : {
+          "title" : "Slot",
+          "description" : "The name of the Postgres logical decoding slot created for streaming changes from a plugin.Defaults to 'debezium",
+          "default" : "debezium",
+          "type" : "string",
+          "x-name" : "slot.name",
+          "x-category" : "CONNECTION_ADVANCED_REPLICATION"
+        },
+        "publication.name" : {
+          "title" : "Publication",
+          "description" : "The name of the Postgres 10+ publication used for streaming changes from a plugin.Defaults to 'dbz_publication'",
+          "default" : "dbz_publication",
+          "type" : "string",
+          "x-name" : "publication.name",
+          "x-category" : "CONNECTION_ADVANCED_REPLICATION"
+        },
+        "publication.autocreate.mode" : {
+          "title" : "Publication Auto Create Mode",
+          "description" : "Applies only when streaming changes using pgoutput.Determine how creation of a publication should work, the default is all_tables.DISABLED - The connector will not attempt to create a publication at all. The expectation is that the user has created the publication up-front. If the publication isn't found to exist upon startup, the connector will throw an exception and stop.ALL_TABLES - If no publication exists, the connector will create a new publication for all tables. Note this requires that the configured user has access. If the publication already exists, it will be used. i.e CREATE PUBLICATION <publication_name> FOR ALL TABLES;FILTERED - If no publication exists, the connector will create a new publication for all those tables matchingthe current filter configuration (see table/database include/exclude list properties). If the publication already exists, it will be used. i.e CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, etc>",
+          "default" : "all_tables",
+          "enum" : [ "filtered", "disabled", "all_tables" ],
+          "type" : "string",
+          "x-name" : "publication.autocreate.mode",
+          "x-category" : "CONNECTION_ADVANCED_REPLICATION"
+        },
+        "schema.include.list" : {
+          "format" : "list,regex",
+          "title" : "Include Schemas",
+          "description" : "The schemas for which events should be captured",
+          "type" : "string",
+          "x-name" : "schema.include.list",
           "x-category" : "FILTERS"
         },
-        "database.exclude.list" : {
+        "schema.exclude.list" : {
           "format" : "list,regex",
-          "title" : "Exclude Databases",
-          "description" : "A comma-separated list of regular expressions that match database names to be excluded from monitoring",
+          "title" : "Exclude Schemas",
+          "description" : "The schemas for which events must not be captured",
           "type" : "string",
-          "x-name" : "database.exclude.list",
+          "x-name" : "schema.exclude.list",
           "x-category" : "FILTERS"
         },
         "table.include.list" : {
@@ -124,9 +147,9 @@
         },
         "snapshot.mode" : {
           "title" : "Snapshot mode",
-          "description" : "The criteria for running a snapshot upon startup of the connector. Options include: 'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; 'schema_only' to only take a snapshot of the schema (table structures) but no actual data; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. The 'never' mode should be used with care, and only when the binlog is known to contain all history.",
+          "description" : "The criteria for running a snapshot upon startup of the connector. Options include: 'always' to specify that the connector run a snapshot each time it starts up; 'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; 'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally start emitting changes;'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the last position (LSN) recorded by the server; and'exported' deprecated, use 'initial' instead; 'custom' to specify a custom class with 'snapshot.custom_class' which will be loaded and used to determine the snapshot, see docs for more details.",
           "default" : "initial",
-          "enum" : [ "never", "initial_only", "when_needed", "initial", "schema_only", "schema_only_recovery" ],
+          "enum" : [ "always", "exported", "never", "initial_only", "initial", "custom" ],
           "type" : "string",
           "x-name" : "snapshot.mode",
           "x-category" : "CONNECTOR_SNAPSHOT"
@@ -196,9 +219,9 @@
         }
       },
       "additionalProperties" : true,
-      "x-connector-id" : "mysql",
-      "x-version" : "1.9.0.Alpha1",
-      "x-className" : "io.debezium.connector.mysql.MySqlConnector",
+      "x-connector-id" : "postgres",
+      "x-version" : "1.9.0.Alpha2",
+      "x-className" : "io.debezium.connector.postgresql.PostgresConnector",
       "$defs" : {
         "serializer" : {
           "type" : "string",
@@ -210,15 +233,15 @@
   },
   "channels" : {
     "stable" : {
-      "revision" : 3,
+      "revision" : 4,
       "shard_metadata" : {
         "operators" : [ {
           "type" : "debezium-connector-operator",
           "version" : "[1.0.0,2.0.0)"
         } ],
         "connector_type" : "source",
-        "connector_class" : "io.debezium.connector.mysql.MySqlConnector",
-        "container_image" : "quay.io/rhoas/cos-connector-debezium-mysql@sha256:13c1440e72d644ca7bce7617fa5b388abbaa47b5532cfd7debb75299adaf875e"
+        "connector_class" : "io.debezium.connector.postgresql.PostgresConnector",
+        "container_image" : "quay.io/rhoas/cos-connector-debezium-postgres:nightly"
       }
     }
   }

--- a/descriptors/sqlserver/debezium-sqlserver-1.9.0.Alpha2.json
+++ b/descriptors/sqlserver/debezium-sqlserver-1.9.0.Alpha2.json
@@ -1,15 +1,15 @@
 {
   "connector_type" : {
-    "id" : "debezium-sqlserver-1.9.0.Alpha1",
+    "id" : "debezium-sqlserver-1.9.0.Alpha2",
     "kind" : "ConnectorType",
-    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-sqlserver-1.9.0.Alpha1",
+    "href" : "/api/connector_mgmt/v1/kafka_connector_types/debezium-sqlserver-1.9.0.Alpha2",
     "name" : "Debezium SqlSever Connector",
-    "version" : "1.9.0.Alpha1",
+    "version" : "1.9.0.Alpha2",
     "channels" : [ "stable" ],
     "description" : null,
-    "labels" : [ "source", "debezium", "sqlserver", "1.9.0.Alpha1" ],
+    "labels" : [ "source", "debezium", "sqlserver", "1.9.0.Alpha2" ],
     "capabilities" : [ "data_shape" ],
-    "icon_href" : "http://example.com/images/debezium-sqlserver-1.9.0.Alpha1.png",
+    "icon_href" : "http://example.com/images/debezium-sqlserver-1.9.0.Alpha2.png",
     "schema" : {
       "title" : "Debezium SqlSever Connector",
       "required" : [ "database.server.name", "database.dbname", "database.hostname" ],
@@ -178,7 +178,7 @@
       },
       "additionalProperties" : true,
       "x-connector-id" : "sqlserver",
-      "x-version" : "1.9.0.Alpha1",
+      "x-version" : "1.9.0.Alpha2",
       "x-className" : "io.debezium.connector.sqlserver.SqlServerConnector",
       "$defs" : {
         "serializer" : {
@@ -191,7 +191,7 @@
   },
   "channels" : {
     "stable" : {
-      "revision" : 1,
+      "revision" : 2,
       "shard_metadata" : {
         "operators" : [ {
           "type" : "debezium-connector-operator",
@@ -199,7 +199,7 @@
         } ],
         "connector_type" : "source",
         "connector_class" : "io.debezium.connector.sqlserver.SqlServerConnector",
-        "container_image" : "quay.io/rhoas/cos-connector-debezium-sqlserver@sha256:036bdfc759e735e1f2dc6f50285b6b4fe6be1202a6dac1c42b182606383f51cd"
+        "container_image" : "quay.io/rhoas/cos-connector-debezium-sqlserver:nightly"
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <debezium.schemabuilder.version>1.9.0-SNAPSHOT</debezium.schemabuilder.version>
-    <debezium.base.version>1.9.0.Alpha1</debezium.base.version>
+    <debezium.base.version>1.9.0.Alpha2</debezium.base.version>
     <kafka.version>3.0.0</kafka.version>
     <descriptor.output.directory>${project.basedir}/descriptors</descriptor.output.directory>
     <maven.compiler.plugin.version>3.9.0</maven.compiler.plugin.version>

--- a/src/main/resources/channels-mongodb-1.9.json
+++ b/src/main/resources/channels-mongodb-1.9.json
@@ -1,6 +1,6 @@
 {
   "stable": {
-    "revision": 3,
+    "revision": 4,
     "shard_metadata": {
       "operators": [
         {
@@ -10,7 +10,7 @@
       ],
       "connector_type": "source",
       "connector_class": "io.debezium.connector.mongodb.MongoDbConnector",
-      "container_image": "quay.io/rhoas/cos-connector-debezium-mongodb@sha256:sha256:7bcb62e2aa02ef100c86ee2697069e435f8365469d7e3df9126731909b83d016"
+      "container_image": "quay.io/rhoas/cos-connector-debezium-mongodb:nightly"
     }
   }
 }

--- a/src/main/resources/channels-mysql-1.9.json
+++ b/src/main/resources/channels-mysql-1.9.json
@@ -1,6 +1,6 @@
 {
   "stable": {
-    "revision": 3,
+    "revision": 4,
     "shard_metadata": {
       "operators": [
         {
@@ -10,7 +10,7 @@
       ],
       "connector_type": "source",
       "connector_class": "io.debezium.connector.mysql.MySqlConnector",
-      "container_image": "quay.io/rhoas/cos-connector-debezium-mysql@sha256:13c1440e72d644ca7bce7617fa5b388abbaa47b5532cfd7debb75299adaf875e"
+      "container_image": "quay.io/rhoas/cos-connector-debezium-mysql:nightly"
     }
   }
 }

--- a/src/main/resources/channels-postgres-1.9.json
+++ b/src/main/resources/channels-postgres-1.9.json
@@ -1,6 +1,6 @@
 {
   "stable": {
-    "revision": 3,
+    "revision": 4,
     "shard_metadata": {
       "operators": [
         {
@@ -10,7 +10,7 @@
       ],
       "connector_type": "source",
       "connector_class": "io.debezium.connector.postgresql.PostgresConnector",
-      "container_image": "quay.io/rhoas/cos-connector-debezium-postgres@sha256:3d86a5b1e0c998895699e6ca1bfbf1c6c41907037392346bb09710bdee895b55"
+      "container_image": "quay.io/rhoas/cos-connector-debezium-postgres:nightly"
     }
   }
 }

--- a/src/main/resources/channels-sqlserver-1.9.json
+++ b/src/main/resources/channels-sqlserver-1.9.json
@@ -1,6 +1,6 @@
 {
   "stable": {
-    "revision": 1,
+    "revision": 2,
     "shard_metadata": {
       "operators": [
         {
@@ -10,7 +10,7 @@
       ],
       "connector_type": "source",
       "connector_class": "io.debezium.connector.sqlserver.SqlServerConnector",
-      "container_image": "quay.io/rhoas/cos-connector-debezium-sqlserver@sha256:036bdfc759e735e1f2dc6f50285b6b4fe6be1202a6dac1c42b182606383f51cd"
+      "container_image": "quay.io/rhoas/cos-connector-debezium-sqlserver:nightly"
     }
   }
 }


### PR DESCRIPTION
This PR explicitly uses the version tag rather than the sha coordinates for Debezium 1.9.  I looked at the camel registry and they also use versions.  This avoids pulling problems from the image repository when a new image is pushed and we don't update the SHA values in the catalog for the new builds.