### PR TITLE
MGDCTRS-585 data_shape "JSON without schema" and  MGDCTRS-629 enable Mongo DB SSL config property

### DIFF
--- a/descriptors/mongodb/debezium-mongodb-1.9.0.Alpha2.json
+++ b/descriptors/mongodb/debezium-mongodb-1.9.0.Alpha2.json
@@ -54,6 +54,14 @@
           "x-name" : "mongodb.password",
           "x-category" : "CONNECTION"
         },
+        "mongodb.ssl.enabled" : {
+          "title" : "Enable SSL connection to MongoDB",
+          "description" : "Should connector use SSL to connect to MongoDB instances",
+          "default" : false,
+          "type" : "boolean",
+          "x-name" : "mongodb.ssl.enabled",
+          "x-category" : "CONNECTION_ADVANCED_SSL"
+        },
         "mongodb.authsource" : {
           "title" : "Credentials Database",
           "description" : "Database containing user credentials.",
@@ -163,7 +171,7 @@
       "$defs" : {
         "serializer" : {
           "type" : "string",
-          "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+          "enum" : [ "JSON", "AVRO", "JSON without schema" ],
           "default" : "JSON"
         }
       }

--- a/descriptors/mysql/debezium-mysql-1.9.0.Alpha2.json
+++ b/descriptors/mysql/debezium-mysql-1.9.0.Alpha2.json
@@ -202,7 +202,7 @@
       "$defs" : {
         "serializer" : {
           "type" : "string",
-          "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+          "enum" : [ "JSON", "AVRO", "JSON without schema" ],
           "default" : "JSON"
         }
       }

--- a/descriptors/postgres/debezium-postgres-1.9.0.Alpha2.json
+++ b/descriptors/postgres/debezium-postgres-1.9.0.Alpha2.json
@@ -225,7 +225,7 @@
       "$defs" : {
         "serializer" : {
           "type" : "string",
-          "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+          "enum" : [ "JSON", "AVRO", "JSON without schema" ],
           "default" : "JSON"
         }
       }

--- a/descriptors/sqlserver/debezium-sqlserver-1.9.0.Alpha2.json
+++ b/descriptors/sqlserver/debezium-sqlserver-1.9.0.Alpha2.json
@@ -183,7 +183,7 @@
       "$defs" : {
         "serializer" : {
           "type" : "string",
-          "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+          "enum" : [ "JSON", "AVRO", "JSON without schema" ],
           "default" : "JSON"
         }
       }

--- a/src/main/java/io/debezium/mcs/schema/ManagedConnectorsSchema.java
+++ b/src/main/java/io/debezium/mcs/schema/ManagedConnectorsSchema.java
@@ -45,6 +45,7 @@ public class ManagedConnectorsSchema implements Schema {
             "mongodb.user",
             "mongodb.password",
             "mongodb.authsource",
+            "mongodb.ssl.enabled",
             "collection.include.list",
             "collection.exclude.list",
             "field.exclude.list",

--- a/src/main/resources/additional_definitions.json
+++ b/src/main/resources/additional_definitions.json
@@ -1,7 +1,7 @@
 {
   "serializer" : {
     "type" : "string",
-    "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+    "enum" : [ "JSON", "AVRO", "JSON without schema" ],
     "default" : "JSON"
   }
 }

--- a/templates/cos-fleet-catalog-debezium.yaml
+++ b/templates/cos-fleet-catalog-debezium.yaml
@@ -67,6 +67,14 @@ objects:
                 "x-name" : "mongodb.password",
                 "x-category" : "CONNECTION"
               },
+              "mongodb.ssl.enabled" : {
+                "title" : "Enable SSL connection to MongoDB",
+                "description" : "Should connector use SSL to connect to MongoDB instances",
+                "default" : false,
+                "type" : "boolean",
+                "x-name" : "mongodb.ssl.enabled",
+                "x-category" : "CONNECTION_ADVANCED_SSL"
+              },
               "mongodb.authsource" : {
                 "title" : "Credentials Database",
                 "description" : "Database containing user credentials.",
@@ -176,7 +184,7 @@ objects:
             "$defs" : {
               "serializer" : {
                 "type" : "string",
-                "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+                "enum" : [ "JSON", "AVRO", "JSON without schema" ],
                 "default" : "JSON"
               }
             }
@@ -409,7 +417,7 @@ objects:
             "$defs" : {
               "serializer" : {
                 "type" : "string",
-                "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+                "enum" : [ "JSON", "AVRO", "JSON without schema" ],
                 "default" : "JSON"
               }
             }
@@ -665,7 +673,7 @@ objects:
             "$defs" : {
               "serializer" : {
                 "type" : "string",
-                "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+                "enum" : [ "JSON", "AVRO", "JSON without schema" ],
                 "default" : "JSON"
               }
             }
@@ -879,7 +887,7 @@ objects:
             "$defs" : {
               "serializer" : {
                 "type" : "string",
-                "enum" : [ "JSON", "AVRO", "JSON_WITHOUT_SCHEMA" ],
+                "enum" : [ "JSON", "AVRO", "JSON without schema" ],
                 "default" : "JSON"
               }
             }


### PR DESCRIPTION
MGDCTRS-585 Use human readable data_shape value `JSON without schema` instead of `JSON_WITHOUT_SCHEMA`
MGDCTRS-629 Update catalog to enable `mongodb.ssl.enabled` option for Mongo DB connector

closes https://issues.redhat.com/browse/MGDCTRS-585
closes https://issues.redhat.com/browse/MGDCTRS-629